### PR TITLE
Fix titles in the readme's documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,26 +102,26 @@ void mousePressed() {
 ```
 
 
-##DOCUMENTATION
-###The 'Gif' Class
+## DOCUMENTATION
+### The 'Gif' Class
 
-####void play()
+#### void play()
 plays the animation without loop
 
-####void pause()
+#### void pause()
 pauses the animation
 
-####void stop()
+#### void stop()
 stops and rewinds the animation
 
-####void loop()
+#### void loop()
 starts the animation. it will play in a loop and ignore the
 GIF repeat setting.
 
-####void noLoop()
+#### void noLoop()
 disables looping
 
-####void ignoreRepeat()
+#### void ignoreRepeat()
 GIF-files can have a repeat-count setting. It states the amount of loops this animation should perform. if you call `ignoreRepeat()` on a Gif object, it will ingore this setting when playing. If you start animations using `loop()`, repeat settings will always be ignored.
 
 #### void jump(int where)


### PR DESCRIPTION
This fixes some titles in the documentation section of the readme.
Titles need a space between the `#` signs and the title text.